### PR TITLE
Formulario de contacto: destinatario configurable por SOPORTE_EMAIL

### DIFF
--- a/app/services/correo.php
+++ b/app/services/correo.php
@@ -122,6 +122,11 @@ class Correo
                 $nombreUsuario = isset($dataUsuario['nombre']) ? $dataUsuario['nombre'] : '';
                 $mensajeUsuario = trim($dataUsuario['mensaje']);
 
+                // Buzon que recibe los mensajes del formulario. Configurable por .env
+                // (SOPORTE_EMAIL) para cambiarlo sin tocar codigo ni redesplegar; si no
+                // esta definido, se mantiene el destino de siempre.
+                $emailSoporte = $_ENV['SOPORTE_EMAIL'] ?? 'soporte@app-energiasolarcanarias.com';
+
                 // Configuración SMTP
                 $this->mail->isSMTP();
                 $this->mail->Host = $this->host; // Servidor SMTP
@@ -168,7 +173,7 @@ class Correo
 
                 // **Correo para soporte**
                 $this->mail->setFrom('admin@app-energiasolarcanarias.com', 'Formulario de Contacto');
-                $this->mail->addAddress('soporte@app-energiasolarcanarias.com', 'Soporte'); // Dirección de soporte
+                $this->mail->addAddress($emailSoporte, 'Soporte'); // Dirección de soporte (SOPORTE_EMAIL)
                 $this->mail->addReplyTo($emailUsuario, $nombreUsuario); // Permitir respuesta al remitente
 
                 $this->mail->isHTML(true);

--- a/config/claves_example.env
+++ b/config/claves_example.env
@@ -6,6 +6,10 @@ LOGIN_BLOQUEO_MIN=15
 # URL de la PWA/frontend (para el enlace del email de login)
 FRONTEND_URL=https://app.energiasolarcanarias.com
 
+# Buzon que recibe los mensajes del formulario de contacto (pagina de ayuda).
+# Si no se define, se usa soporte@app-energiasolarcanarias.com.
+SOPORTE_EMAIL=soporte@galagaagency.com
+
 # Proxies de confianza para leer la IP real del cliente (X-Forwarded-For).
 # Solo si la peticion viene de uno de estos se cree el XFF. Separados por coma; cada
 # entrada es una IP exacta (172.18.0.1) o un rango CIDR (172.16.0.0/12). Como la


### PR DESCRIPTION
El buzon que recibe los mensajes del formulario de ayuda estaba hardcodeado (soporte@app-energiasolarcanarias.com). Pasa a leerse de $_ENV['SOPORTE_EMAIL'], con fallback al valor de siempre si no esta definido, para poder cambiarlo sin tocar codigo ni redesplegar. Documentado en claves_example.env.